### PR TITLE
Update SandboxFunctions4_0New.R

### DIFF
--- a/R/SandboxFunctions4_0New.R
+++ b/R/SandboxFunctions4_0New.R
@@ -212,12 +212,33 @@ postDataToBOAv2 <- function(df, dfname, fieldtypes = NULL) {
 # will drop table, then append a list of dataframes together into the target schema.tblname
 fastLoadUtil <- function (df, rows_to_chop_by, tblname, schma) 
 {
+  #Ex.
+  #fastLoadUtil(Test_df, 1000, "Test_tblname" , "Test_schma")
+  
+  suppressPackageStartupMessages(require(dplyr))
+  suppressPackageStartupMessages(require(lubridate))
+  require(DBI)
+  require(devtools)
+  require(CommonFunctions)
+  require(Connections)
+  
+  .GlobalEnv$LogEvent <- CommonFunctions::LogEvent
+  .GlobalEnv$qryBOAExecute <- CommonFunctions::qryBOAExecute
+  .GlobalEnv$odbcConnStrBOA <- Connections::odbcConnStrBOA
+  .GlobalEnv$postDataToBOAAppend <- CommonFunctions::postDataToBOAAppend
+  
+  if(!exists("LogFile")){
+    .GlobalEnv$LogFile <- paste0(rstudioapi::getSourceEditorContext()$path,"_LogFile.txt")
+    message(paste0("Note: No 'LogFile' defined, Log saved to ",LogFile))
+  }
   
   rowsinfile <- rows_to_chop_by
   myDataFileCount <- as.integer((nrow(df)/rowsinfile)+1)
   
   i <- 1
   myData <- list()
+  
+  Start_time <- Sys.time()
   
   #loop to filter and populate the list
   while (i <= myDataFileCount) 
@@ -254,7 +275,13 @@ fastLoadUtil <- function (df, rows_to_chop_by, tblname, schma)
     
     c <- c + 1
     
+    
   }
+  
+  End_time <- Sys.time()
+  message(nrow(df)," rows loaded in ",round(difftime(End_time, Start_time, units = "mins"), 2) , " mins. Loaded ", rows_to_chop_by, " rows at a time.")
+  LogEvent(paste0(nrow(df)," rows loaded in ", round(difftime(End_time, Start_time, units = "mins"), 2), " mins. Loaded ", rows_to_chop_by, " rows at a time."), LogFile)
+
 }
 
 
@@ -299,6 +326,7 @@ LogEvent <- function (LogString, LogFile) {
   log_con <- file(LogFile, open="a")
   log_string <- paste(now(), ": ", LogString)
   cat(log_string, file = log_con, sep="\n")
+  close(log_con)
 }
 
 # Message2Log


### PR DESCRIPTION
- Adding commented out ex. inputs for function use to show where "" are needed.  ----- I find this is always my first thought when using a custom function is how I need to format the inputs.

-  Adding packages to load via require() for the function to work.  ----- The library() by default returns an error if the requested package does not exist. The require() is designed to be used inside functions as it gives a warning message and returns a logical value say, FALSE if the requested package is not found and TRUE if the package is loaded. ----- suppressPackageStartupMessages() on dplyr and lubridate to avoid the bunch of warnings about packages within that are masked.

- Function was failing if LogFile object wasnt defined prior to being run. Added code to create a LogFile if the object doesnt exist in env.  ----- Newly defined/created LogFile saved to Global Environment from inside the function by defining with .GlobalEnv$LogFile. Without ".GlobalEnv" object created in function would not be accessible after function runs.  ----- LogFile location, if not defined, defaults dynamically to the location the Rscript is saved to by using "rstudioapi::getSourceEditorContext()$path" to find current file location. Message then sent to user saying where file saved.  ----- Ex. output - "Note: No 'LogFile' defined, Log saved to C:/Users/ADDLERX/OneDrive - Abbott/Rachel Personal OneDrive/Sr. Analyst Data Management/TestFastLoadFunction.R_LogFile.txt"

- Brought in necessary CommonFunctions & Connections to Global Environment for user viewing for debug ease.

- Added start & end time to create message/log difftime for how many rows loaded and by what # of rows it was executed.  ----- Ex. output - "2023-01-20 07:55:49 :  4000 rows loaded in 0.21 mins. Loaded 1000 rows at a time."

- Added close(log_con) to LogEvent Function. open="a" appends files but opens a new connection each time to not overwrite last append. This avoids multiple warnings that appear at end of script runs for unused connections.  ----- Ex. warning - "7: In for (n in impnames) if (!is.null(genImp <- impenv[[n]])) { :
  closing unused connection 3 (C:/Users/ADDLERX/OneDrive - Abbott/Rachel Personal OneDrive/Sr. Analyst Data Management/TestFastLoadFunction.R_LogFile.txt)"

** Emailing you my test RScript to use this version of function.