### PR TITLE
filter change on fastload utility function

### DIFF
--- a/R/SandboxFunctions4_0New.R
+++ b/R/SandboxFunctions4_0New.R
@@ -224,8 +224,7 @@ fastLoadUtil <- function (df, rows_to_chop_by, tblname, schma, LogFilePath)
   while (i <= myDataFileCount)
   {
 
-    myData[[i]] <- df %>%
-      filter((row(df) <= (rowsinfile*i)) & (row(df) > (rowsinfile*(i-1))))
+    myData[[i]] <- base::subset(df, (row(df) <= (rowsinfile*i)) & (row(df) > (rowsinfile*(i-1))))
 
     LogEvent(paste0("myData list build #:", i, " of ", myDataFileCount), LogFile)
 


### PR DESCRIPTION
changing this to use the base::subset() function vs. dplyr::filter().  The filter() function from dplyr library keeps giving us fits if we're not using the correct "version" of dplyr and trying to filter matrixes.  The subset function doesn't care; we're not doing anything fancy here, we just need to chop a dataset up into a list of files.

confirmed the filter works with a simple test:

![image](https://github.com/ANPD-Data-Analytics/CommonFunctions/assets/79851819/71395f2c-61b0-46e1-b04e-16340133bf2d)

![image](https://github.com/ANPD-Data-Analytics/CommonFunctions/assets/79851819/d2f14ee4-17e1-4620-8a46-2dd74b9691a0)


